### PR TITLE
New option for function make tile: keep_chroms

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Authors
 =======
 
 * Wolfgang Kopp - `@wkopp <https://github.com/wkopp>`_
+* Pia Rautenstrauch - `@prauten <https://github.com/prauten>`_

--- a/src/scregseg/countmatrix.py
+++ b/src/scregseg/countmatrix.py
@@ -153,8 +153,9 @@ def make_counting_bins(file, binsize, storage=None, remove_chroms=[], keep_chrom
     storage : path or None
        Output path of the BED file.
     remove_chroms : list
-       List of chromosomes to remove. Default=[]
+       List of chromosomes to remove. Default=['chrM', 'chrY', 'chrX']
     keep_chroms: None or list(str)
+       List of chromosomes to keep. Default=None
 
     Returns
     -------

--- a/src/scregseg/countmatrix.py
+++ b/src/scregseg/countmatrix.py
@@ -153,7 +153,7 @@ def make_counting_bins(file, binsize, storage=None, remove_chroms=[], keep_chrom
     storage : path or None
        Output path of the BED file.
     remove_chroms : list
-       List of chromosomes to remove. Default=['chrM', 'chrY', 'chrX']
+       List of chromosomes to remove. Default=[]
     keep_chroms: None or list(str)
        List of chromosomes to keep. Default=None
 


### PR DESCRIPTION
I added a new optional option to the make_tile function that allows you to select those chromosomes from which you want to keep the fragments. If this option is enabled, the remove_chroms option is ignored. If keep_chroms is not used as an argument, the function runs as before.

Unfortunately, opening the files in PyCharm seems to have changed some of the indentation and spaces, too.

I read the contributing guidelines but could not comply with all of them yet.

For reference, they are:
1. Include passing tests (run tox);
2. Update documentation when there's new API, functionality etc.
3. Add a note to CHANGELOG.rst about the changes.
4. Add yourself to AUTHORS.rst.

Regarding 1: I ran tox, not all tests succeeded, but this is not due to the novel added functionality but must stem from previous issues.

Regarding 2: I am happy to add a line about this in the jupyter notebook if you want to.

Regarding 3: The CHANGELOG.rst is currently not up to date, such that I disregarded this for now.

Regarding 4: Done.