### PR TITLE
Fix minregioncount of fit_segment function by adding setters for attr…

### DIFF
--- a/src/scregseg/countmatrix.py
+++ b/src/scregseg/countmatrix.py
@@ -65,8 +65,7 @@ def load_count_matrices(countfiles, bedfile, mincounts,
         for i, _ in enumerate(data):
             keepregions = np.where((regioncounts >= minregioncounts) & (regioncounts <= maxregioncounts))[0]
 
-            data[i].cmat = data[i].cmat[keepregions, :]
-            data[i].regions = data[i].regions.iloc[keepregions]
+            data[i].adata = data[i].adata[keepregions, :].copy()
     return data
 
 
@@ -1018,10 +1017,6 @@ class CountMatrix:
     def cmat(self):
         return self.adata.X
 
-    @cmat.setter
-    def cmat(self, value):
-        self._cmat = value
-
     @property
     def cannot(self):
         return self.adata.var
@@ -1029,10 +1024,6 @@ class CountMatrix:
     @property
     def regions(self):
         return self.adata.obs
-
-    @regions.setter
-    def regions(self, value):
-        self._regions = value
 
     def remove_chroms(self, chroms):
         """Remove chromsomes."""

--- a/src/scregseg/countmatrix.py
+++ b/src/scregseg/countmatrix.py
@@ -1018,6 +1018,10 @@ class CountMatrix:
     def cmat(self):
         return self.adata.X
 
+    @cmat.setter
+    def cmat(self, value):
+        self._cmat = value
+
     @property
     def cannot(self):
         return self.adata.var
@@ -1025,6 +1029,10 @@ class CountMatrix:
     @property
     def regions(self):
         return self.adata.obs
+
+    @regions.setter
+    def regions(self, value):
+        self._regions = value
 
     def remove_chroms(self, chroms):
         """Remove chromsomes."""


### PR DESCRIPTION
…ibutes decorated with ```@property``` that are modified if minregioncount is used as an argument.

Hi Wolfgang, 

When using the ```--minregioncount``` flag for the scregseg method ```fit_segment``` currently the following error is thrown:

```
Traceback (most recent call last):
  File ".../bin/scregseg", line 33, in <module>
    sys.exit(load_entry_point('scregseg', 'console_scripts', 'scregseg')())
  File ".../scregseg/src/scregseg/cli.py", line 849, in main
    local_main(args)
  File ".../scregseg/src/scregseg/cli.py", line 649, in local_main
    args.trimcounts, args.minregioncounts)
  File ".../scregseg/src/scregseg/countmatrix.py", line 69, in load_count_matrices
    data[i].regions = data[i].regions.iloc[keepregions]
AttributeError: can't set attribute
```

Same error is thrown by line 70 in ```load_count_matrices```: ```data[i].regions = data[i].regions.iloc[keepregions]```

This is because these attributes of the countmatrix class are decorated with @property. Such attributes require setter methods to be changed.

I added those setters in this pull request.

Best,
Pia