### PR TITLE
Fix mixed data type issues caused by memory efficient loading by pand…

### DIFF
--- a/src/scregseg/countmatrix.py
+++ b/src/scregseg/countmatrix.py
@@ -106,7 +106,7 @@ def get_genome_size_from_tsv(file):
     dict
         Dict with keys and values corresponding to chromosome names and lengths, respectively.
     """
-    df = BedTool(file).to_dataframe()
+    df = BedTool(file).to_dataframe(dtype={'chrom': str, 'start': 'int', 'end': 'int', 'name': str, 'score': int}, comment='#')
     chroms = df.chrom.unique()
     genomesize = {}
     for chrom in chroms:
@@ -744,7 +744,8 @@ def get_regions_from_bed_(filename):
     """
     regions = pd.read_csv(filename, sep='\t',
                           names=['chrom', 'start', 'end'],
-                          usecols=[0,1,2])
+                          usecols=[0,1,2], dtype={'chrom': str, 'start': 'int', 'end': 'int'})
+
     regions.loc[:, 'name'] = regions.apply(lambda row: f'{row.chrom}_{row.start}_{row.end}', axis=1)
     regions.set_index('name', inplace=True)
     return regions


### PR DESCRIPTION
…as when using Ensembl annotations (chromosome naming conventions).

Hi Wolfgang, 

This pull request addresses issues I ran into when working with ATAC fragment files following Ensembl genome annotations ("1"/1 instead of "chr1", ..., and having headers). The memory-efficient data loading strategy from pandas (pd.read_csv - also internally called by BedTool()) led to mixed data types (e.g., chromosome 1 being represented as "1" and 1) causing inconsistent values for some chromosomes and if a header is present, start and end being read as float instead of an integer as required elsewhere in the code.

The implemented changes should be downward compatible.

Let me know if you have any questions.

Best,
Pia